### PR TITLE
[[DOCS]] Added an example to the docs for the globals option

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -760,7 +760,11 @@ exports.val = {
    * Setting an entry to `true` enables reading and writing to that variable.
    * Setting it to `false` will trigger JSHint to consider that variable
    * read-only.
-   *
+   * 
+   * This option accepts an object, like so:
+   * 
+   *   // jshint globals:{"React": false, "_": false}
+   * 
    * See also the "environment" options: a set of options to be used as short
    * hand for enabling global variables defined in common JavaScript
    * environments.


### PR DESCRIPTION
The `globals` option requires an object, but this doesn't appear to be documented.